### PR TITLE
Enable SYSCFG clock and fix bug in EXTI configuring

### DIFF
--- a/button/nvic.c
+++ b/button/nvic.c
@@ -131,7 +131,7 @@ exti_sysconfig ( int gpio, int pin, int line )
 	    return;
 
 	sp->exti_conf[l_index] &= ~(0xf<<l_shift);
-	sp->exti_conf[l_index] |= ~(p_val<<l_shift);
+	sp->exti_conf[l_index] |= p_val<<l_shift;
 }
 
 static vfptr exti_hook;

--- a/button/rcc.c
+++ b/button/rcc.c
@@ -120,6 +120,7 @@ struct rcc {
 /* On APB2 */
 #define UART1_ENABLE	0x10
 #define UART3_ENABLE	0x20
+#define SYSCFG_ENABLE	0x4000
 
 /* In the PLL register */
 
@@ -367,6 +368,7 @@ rcc_init ( void )
 
 	rp->apb2_e |= UART1_ENABLE;
 	rp->apb2_e |= UART3_ENABLE;
+	rp->apb2_e |= SYSCFG_ENABLE;
 
 	cpu_clock_init ();
 }


### PR DESCRIPTION
Hello @trebisky. Thx for sharing this project, it's very useful to study.

While discovering "button" section, I see bug in configuring SYSCFG_EXTICR1.
Documentation say next values for pins:
> 0000: PA[x] pin
> 0001: PB[x] pin
> 0010: PC[x] pin
> 
But code is set `1111` for PA.
But I still can see button response. And after some investigation i see that configuring SYSCFG_EXTICR1 doesn't work at all because of disabled SYSCFG clocking. So exti_conf remains 0, and button "works" for PA.

In this patch i fix those problems.